### PR TITLE
feat: Webhook自動ダウンロードシステム完成

### DIFF
--- a/node-bot/package.json
+++ b/node-bot/package.json
@@ -10,14 +10,15 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "discord.js": "^14.15.3",
-    "@discordjs/voice": "^0.18.0",
     "@discordjs/opus": "^0.9.0",
-    "sodium-native": "^4.0.4",
-    "prism-media": "^1.3.5",
-    "fluent-ffmpeg": "^2.1.3",
+    "@discordjs/voice": "^0.18.0",
     "axios": "^1.7.7",
+    "discord.js": "^14.15.3",
     "dotenv": "^16.4.5",
+    "express": "^5.1.0",
+    "fluent-ffmpeg": "^2.1.3",
+    "prism-media": "^1.3.5",
+    "sodium-native": "^4.0.4",
     "winston": "^3.14.2"
   },
   "engines": {

--- a/node-bot/src/logger.js
+++ b/node-bot/src/logger.js
@@ -1,0 +1,40 @@
+import winston from 'winston';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs/promises';
+
+// Get current directory for ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Ensure log directory exists
+await fs.mkdir(path.join(__dirname, '..', 'logs'), { recursive: true });
+
+// Configure logger
+const logger = winston.createLogger({
+  level: process.env.LOG_LEVEL || 'info',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.errors({ stack: true }),
+    winston.format.json()
+  ),
+  defaultMeta: { service: 'voice-meeting-bot' },
+  transports: [
+    new winston.transports.File({ 
+      filename: path.join(__dirname, '..', 'logs', 'error.log'), 
+      level: 'error',
+      maxsize: 10 * 1024 * 1024, // 10MB
+      maxFiles: 3
+    }),
+    new winston.transports.File({ 
+      filename: path.join(__dirname, '..', 'logs', 'combined.log'),
+      maxsize: 10 * 1024 * 1024, // 10MB
+      maxFiles: 3
+    }),
+    new winston.transports.Console({
+      format: winston.format.simple()
+    })
+  ]
+});
+
+export default logger;

--- a/node-bot/src/webhook-server.js
+++ b/node-bot/src/webhook-server.js
@@ -1,0 +1,155 @@
+import express from 'express';
+import logger from './logger.js';
+
+class WebhookServer {
+    constructor(bot, voiceRecorder) {
+        this.app = express();
+        this.bot = bot;
+        this.voiceRecorder = voiceRecorder;
+        this.server = null;
+        
+        // Middleware
+        this.app.use(express.json());
+        
+        // Health check endpoint
+        this.app.get('/health', (req, res) => {
+            res.json({ status: 'ok', timestamp: new Date().toISOString() });
+        });
+        
+        // Webhook endpoint for meeting completion
+        this.app.post('/webhook/meeting-completed', async (req, res) => {
+            try {
+                const { meeting_id, event, timestamp, download_links } = req.body;
+                
+                if (event !== 'meeting_completed') {
+                    return res.status(400).json({ error: 'Invalid event type' });
+                }
+                
+                logger.info(`Webhook received for meeting: ${meeting_id}`);
+                
+                // Send download links message to Discord
+                await this.sendDownloadLinksMessage(meeting_id, download_links);
+                
+                res.json({ status: 'success', processed_at: new Date().toISOString() });
+                
+            } catch (error) {
+                logger.error('Webhook processing error:', error);
+                res.status(500).json({ error: 'Internal server error' });
+            }
+        });
+    }
+    
+    async sendDownloadLinksMessage(meetingId, downloadLinks) {
+        try {
+            // Find the channel where the meeting was recorded
+            // This would be stored in the meeting data or passed through the webhook
+            const channelId = await this.getMeetingChannelId(meetingId);
+            
+            if (!channelId) {
+                logger.warn(`No channel found for meeting ${meetingId}`);
+                return;
+            }
+            
+            const channel = this.bot.channels.cache.get(channelId);
+            
+            if (!channel) {
+                logger.warn(`Channel ${channelId} not found in cache`);
+                return;
+            }
+            
+            logger.info(`Found channel: ${channel.name} (${channel.type}), guild: ${channel.guild?.name}`);
+            
+            // Check bot permissions
+            const permissions = channel.permissionsFor(this.bot.user);
+            logger.info(`Bot permissions in channel: SendMessages=${permissions?.has('SendMessages')}, EmbedLinks=${permissions?.has('EmbedLinks')}`);
+            
+            // Create download buttons and message
+            const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = await import('discord.js');
+            
+            const embed = new EmbedBuilder()
+                .setTitle('📊 議事録の準備が完了しました')
+                .setDescription(`ミーティング: \`${meetingId}\`\n\n以下のボタンから各種データをダウンロードできます。`)
+                .setColor('#00ff00')
+                .setTimestamp()
+                .addFields(
+                    { name: '📄 要約・議事録', value: 'Markdown形式の議事録', inline: true },
+                    { name: '📝 転写テキスト', value: '全発言の転写データ', inline: true },
+                    { name: '🎵 音声チャンク', value: '録音データの情報', inline: true }
+                )
+                .setFooter({ text: 'データ保存期限: 7日間' });
+            
+            const row = new ActionRowBuilder()
+                .addComponents(
+                    new ButtonBuilder()
+                        .setCustomId(`download_summary_${meetingId}`)
+                        .setLabel('📊 要約・議事録')
+                        .setStyle(ButtonStyle.Primary),
+                    new ButtonBuilder()
+                        .setCustomId(`download_transcript_${meetingId}`)
+                        .setLabel('📄 転写テキスト')
+                        .setStyle(ButtonStyle.Secondary),
+                    new ButtonBuilder()
+                        .setCustomId(`download_chunks_${meetingId}`)
+                        .setLabel('🎵 音声チャンク')
+                        .setStyle(ButtonStyle.Success)
+                );
+            
+            const sentMessage = await channel.send({
+                embeds: [embed],
+                components: [row]
+            });
+            
+            logger.info(`Download links message sent for meeting ${meetingId} to channel ${channelId}, message ID: ${sentMessage.id}`);
+            
+        } catch (error) {
+            logger.error(`Failed to send download links message for meeting ${meetingId}:`, error);
+        }
+    }
+    
+    async getMeetingChannelId(meetingId) {
+        try {
+            // Use VoiceRecorder to find the recording
+            const recordingInfo = this.voiceRecorder.findRecordingByMeetingId(meetingId);
+            if (recordingInfo) {
+                return recordingInfo.channelId;
+            }
+            
+            // Fallback: could be retrieved from database or other storage
+            logger.warn(`Could not find channel for meeting ${meetingId}`);
+            return null;
+            
+        } catch (error) {
+            logger.error(`Error getting meeting channel ID for ${meetingId}:`, error);
+            return null;
+        }
+    }
+    
+    start(port = 3001) {
+        return new Promise((resolve, reject) => {
+            this.server = this.app.listen(port, (error) => {
+                if (error) {
+                    logger.error('Failed to start webhook server:', error);
+                    reject(error);
+                } else {
+                    logger.info(`Webhook server started on port ${port}`);
+                    resolve();
+                }
+            });
+        });
+    }
+    
+    stop() {
+        return new Promise((resolve) => {
+            if (this.server) {
+                this.server.close(() => {
+                    logger.info('Webhook server stopped');
+                    resolve();
+                });
+            } else {
+                resolve();
+            }
+        });
+    }
+}
+
+export default WebhookServer;

--- a/python-api/src/meeting_manager.py
+++ b/python-api/src/meeting_manager.py
@@ -179,6 +179,37 @@ class MeetingManager:
         finally:
             db.close()
     
+    async def get_transcript_segments(self, meeting_id: str) -> Optional[List[Dict]]:
+        """Get transcript segments as list for download endpoints"""
+        try:
+            db = self.db_session()
+            
+            transcripts = db.query(Transcript).filter(
+                Transcript.meeting_id == meeting_id
+            ).order_by(Transcript.start_time).all()
+            
+            if not transcripts:
+                return None
+            
+            segments = []
+            for transcript in transcripts:
+                segments.append({
+                    'speaker_id': transcript.speaker_id,
+                    'speaker_name': transcript.speaker_name,
+                    'text': transcript.text,
+                    'start_time': transcript.start_time,
+                    'duration_seconds': transcript.duration_seconds,
+                    'audio_file_path': transcript.audio_file_path
+                })
+            
+            return segments
+            
+        except Exception as e:
+            logger.error(f"Error retrieving transcript segments for meeting {meeting_id}: {e}")
+            return None
+        finally:
+            db.close()
+    
     async def save_summary(
         self,
         meeting_id: str,


### PR DESCRIPTION
## Summary
- 録音停止後の自動ダウンロードリンク送信システムを実装
- リアルタイムWebhook通知により、従来のポーリング方式から即座通知に移行
- ボタン付きUI自動生成で、ユーザビリティを大幅向上

## 主要実装内容

### Python API側
- **4つのダウンロードエンドポイント実装**
  - `GET /download/meeting/{id}/summary` - Markdown議事録
  - `GET /download/meeting/{id}/transcript` - プレーンテキスト転写  
  - `GET /download/meeting/{id}/chunks` - 音声チャンク情報JSON
  - `GET /download/meeting/{id}/chunk/{filename}` - 個別音声ファイル

- **Webhook送信機能追加**
  - 要約完了時の自動通知 (http://localhost:3002/webhook/meeting-completed)
  - httpxによる非同期送信、フォールバック機能付き

### Discord Bot側  
- **Webhookサーバー実装** (Express.js, ポート3002)
  - `POST /webhook/meeting-completed` エンドポイント
  - 録音元ボイスチャンネルへの自動メッセージ送信

- **ダウンロードUI自動生成**
  - Embed形式メッセージ + 3つのダウンロードボタン
  - プライベート返信でダウンロードURL表示
  - データ保存期限表示 (7日間)

### システム改善
- **24時間録音情報保持システム**
  - `completedRecordings` マップ追加
  - 自動クリーンアップ機能 (1時間毎)
  - meetingId → channelId 検索機能

## Test plan
- [x] Webhookサーバー起動確認 (ポート3002)
- [x] 録音→要約→Webhook送信フローテスト
- [x] ダウンロードボタン動作確認
- [x] 全4種類ダウンロードエンドポイント動作確認
- [x] 24時間録音情報保持機能テスト
- [ ] フォールバック機能テスト (Webhook失敗時のポーリング継続)
- [ ] セキュリティテスト (パストラバーサル対策等)

## 改善効果
- **即座通知**: ポーリング不要でリアルタイム通知
- **UX向上**: 自動メッセージ + ワンクリックダウンロード
- **システム負荷軽減**: ポーリング頻度削減可能

🤖 Generated with [Claude Code](https://claude.ai/code)